### PR TITLE
Store relative paths in the backup archive

### DIFF
--- a/src/main/java/org/szernex/yabm/core/BackupTask.java
+++ b/src/main/java/org/szernex/yabm/core/BackupTask.java
@@ -12,6 +12,7 @@ import org.szernex.yabm.util.LogHelper;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class BackupTask implements Runnable
@@ -112,8 +113,17 @@ public class BackupTask implements Runnable
 
 			source_files.addAll(FileHelper.getDirectoryContents(world_dir));
 			LogHelper.info("Archiving %d files...", source_files.size());
+			
+			// Convert all paths to relative paths.
+			// This only works if the working directory is the ancestor of all paths.
+			File working_dir = new File("").getAbsoluteFile();
+			Set<File> relative_source_files = new HashSet<File>();
+			for (File f : source_files)
+			{
+				relative_source_files.add(new File(working_dir.toURI().relativize(f.toURI()).getPath()));
+			}
 
-			if (FileHelper.createZipArchive(target_file, source_files, compressionLevel))
+			if (FileHelper.createZipArchive(target_file, relative_source_files, compressionLevel))
 			{
 				LogHelper.info("Successfully created backup archive.");
 			}


### PR DESCRIPTION
Originally absolute paths are stored in the backup archive. This makes
it hard to restore a backup to a different folder structure.

This only works if the working directory is the ancestor of all paths, which
is true for the default backupList option.

This is just a quick fix for my personal usage, but i find it annoying that the backup archive stores the absolute paths to the files. I work under Arch Linux, not sure if it is the same under Windows.
